### PR TITLE
Add support for 116th Congress (new PA districts)

### DIFF
--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -14,7 +14,7 @@ from geocodio import exceptions
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_FIELDS = ['cd', 'cd113', 'cd114', 'cd115', 'census', 'stateleg', 'school', 'timezone']
+ALLOWED_FIELDS = ['cd', 'cd113', 'cd114', 'cd115', 'cd116', 'census', 'stateleg', 'school', 'timezone']
 
 
 def protect_fields(f):


### PR DESCRIPTION
Geocod.io added support for the new PA districts being used for the 2018 election if you use the `cd116` field. This adds support to that field to the python geocod.io client.