### PR TITLE
Add ACS fields

### DIFF
--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -15,7 +15,9 @@ from geocodio import exceptions
 logger = logging.getLogger(__name__)
 
 ALLOWED_FIELDS = [
-    "cd", "cd113", "cd114", "cd115", "cd116", "census", "stateleg", "school", "timezone"
+    "cd", "cd113", "cd114", "cd115", "cd116", "census", "stateleg", "school",
+    "acs-demographics", "acs-economics", "acs-families", "acs-housing", "acs-social",
+    "timezone"
 ]
 
 


### PR DESCRIPTION
Geocode.io now provides [American Community Survey](https://www.census.gov/programs-surveys/acs/) data. See https://www.geocod.io/docs/#fields

This PR adds 5 `acs` field options to the list of allowed fields.