### PR TITLE
Update to API v1.3

### DIFF
--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -79,7 +79,7 @@ class GeocodioClient(object):
     Client connection for Geocod.io API
     """
 
-    BASE_URL = "http://api.geocod.io/v1.2/{verb}"
+    BASE_URL = "http://api.geocod.io/v1.3/{verb}"
 
     def __init__(self, key, order="lat"):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,9 +23,9 @@ from geocodio.data import LocationCollection
 
 class ClientFixtures(object):
     def setUp(self):
-        self.parse_url = "http://api.geocod.io/v1.2/parse"
-        self.geocode_url = "http://api.geocod.io/v1.2/geocode"
-        self.reverse_url = "http://api.geocod.io/v1.2/reverse"
+        self.parse_url = "http://api.geocod.io/v1.3/parse"
+        self.geocode_url = "http://api.geocod.io/v1.3/geocode"
+        self.reverse_url = "http://api.geocod.io/v1.3/reverse"
         self.client = GeocodioClient("1010110101")
         self.err = '{"error": "We are testing"}'
 


### PR DESCRIPTION
- Update client
- Update test client

v1.3 (Released on March 12th, 2018)

timezone appends:

Breaking: name property has been renamed to abbreviation
name is now the full timezone name in a tzdb-compatible format.