### PR TITLE
Switch to HTTPS

### DIFF
--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -83,7 +83,7 @@ class GeocodioClient(object):
     def __init__(self, key, order="lat", version="1.3"):
         """
         """
-        self.BASE_URL = "http://api.geocod.io/v{version}/{{verb}}".format(
+        self.BASE_URL = "https://api.geocod.io/v{version}/{{verb}}".format(
             version=version
         )
         self.API_KEY = key

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,9 +23,9 @@ from geocodio.data import LocationCollection
 
 class ClientFixtures(object):
     def setUp(self):
-        self.parse_url = "http://api.geocod.io/v1.3/parse"
-        self.geocode_url = "http://api.geocod.io/v1.3/geocode"
-        self.reverse_url = "http://api.geocod.io/v1.3/reverse"
+        self.parse_url = "https://api.geocod.io/v1.3/parse"
+        self.geocode_url = "https://api.geocod.io/v1.3/geocode"
+        self.reverse_url = "https://api.geocod.io/v1.3/reverse"
         self.client = GeocodioClient("1010110101")
         self.err = '{"error": "We are testing"}'
 


### PR DESCRIPTION
Do this to be more secure by default.

The Geocodio API docs indicate HTTP is not recommended:

https://www.geocod.io/docs/

```
The base API url is https://api.geocod.io/v1.3/.

You can also use Geocodio over plain HTTP, but it is not recommended.
```