### PR TITLE
Feature/add optional hipaa enabled url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Geocodio API Features
 * Parse an address into its identifiable components
 * Reverse geocode an individual geographic point
 * Batch reverse geocode up to 10,000 points at a time
+* Perform operations using the HIPAA API URL
 
 The service is limited to U.S. and Canada addresses for the time being.
 

--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -79,11 +79,12 @@ class GeocodioClient(object):
     Client connection for Geocod.io API
     """
 
-    def __init__(self, key, order="lat", version="1.3"):
+    def __init__(self, key, order="lat", version="1.3", hipaa_enabled=False):
         """
         """
-        self.BASE_URL = "https://api.geocod.io/v{version}/{{verb}}".format(
-            version=version
+        self.hipaa_enabled = hipaa_enabled
+        self.BASE_URL = "https://api{hipaa_append}.geocod.io/v{version}/{{verb}}".format(
+            version=version, hipaa_append=('-hipaa' if self.hipaa_enabled else '')
         )
         self.API_KEY = key
         if order not in ("lat", "lng"):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,6 +30,18 @@ class ClientFixtures(object):
         self.err = '{"error": "We are testing"}'
 
 
+class TestClientInit(unittest.TestCase):
+    def test_hipaa_enabled(self):
+        client = GeocodioClient("1010110101", hipaa_enabled=True)
+        self.assertTrue(client.hipaa_enabled)
+        self.assertTrue(client.BASE_URL.startswith("https://api-hipaa.geocod.io"))
+
+    def test_hipaa_disabled(self):
+        client = GeocodioClient("1010110101")
+        self.assertFalse(client.hipaa_enabled)
+        self.assertTrue(client.BASE_URL.startswith("https://api.geocod.io"))
+
+
 class TestClientErrors(ClientFixtures, unittest.TestCase):
     @httpretty.activate
     def test_auth_error(self):


### PR DESCRIPTION
This PR adds the ability to enable the use of the geocodio HIPAA API URL (specified in the docs [here](https://www.geocod.io/docs/hipaa/#address-formats-2) )

Changes include:
- New `hipaa_enabled` parameter to init the Geocodio client and enable the use of the HIPAA url (adds the prefix)

Related to: #29