### PR TITLE
Feature/add components search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,9 @@ Geocodio API Features
 =====================
 
 * Geocode an individual address
+* Geocode a dictionary of address components
 * Batch geocode up to 10,000 addresses at a time
+* Batch geocode a list of address components
 * Parse an address into its identifiable components
 * Reverse geocode an individual geographic point
 * Batch reverse geocode up to 10,000 points at a time

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,7 @@ Geocodio API Features
 =====================
 
 * Geocode an individual address
-* Geocode a dictionary of address components
 * Batch geocode up to 10,000 addresses at a time
-* Batch geocode a list of address components
 * Parse an address into its identifiable components
 * Reverse geocode an individual geographic point
 * Batch reverse geocode up to 10,000 points at a time
@@ -79,7 +77,7 @@ Return a list of just the coordinates for the resultant geocoded addresses::
     >>> geocoded_addresses[0].coords
     (38.890083, -76.983822), (37.560446, -77.476008)
 
-Lookup an address by queried address::
+Lookup an address by the queried address::
 
     >>> geocoded_addresses.get('2 15th St NW, Washington, DC 20024').coords
     (38.879138, -76.981879))
@@ -126,7 +124,7 @@ Return the list of formatted addresses::
     >>> locations.formatted_addresses
     ["42370 Bob Hope Dr, Rancho Mirage CA, 92270",  "42370 Bob Hope Dr, Rancho Mirage CA, 92270", "2 15th St NW, Washington, DC 20024"]
 
-Access a specific address by queried point tuple::
+Access a specific address by the queried point tuple::
 
     >>> locations.get("38.890083,-76.983822").formatted_address
     "2 15th St NW, Washington, DC 20024"

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -111,7 +111,8 @@ the entire list.
     checking against the query input.
 
     The key can be the queried address as a string (geocoding) or the queried
-    point (reverse geocoding). The point can be provided as a tuple of floats::
+    point (reverse geocoding) or a dictionary of queried address components.
+    The point can be provided as a tuple of floats::
 
         (33.12, -78.123)
 

--- a/docs/geocode.rst
+++ b/docs/geocode.rst
@@ -11,6 +11,17 @@ Import the API client and ensure you have a valid API key::
     >>> client = GeocodioClient(MY_KEY)
     >>> geocoded_location = client.geocode("42370 Bob Hope Drive, Rancho Mirage CA")
 
+
+You can also geocode using a single dictionary of address components::
+
+    >>> geocoded_location = client.geocode({"street": "42370 Bob Hope Drive",
+        "city": "Rancho Mirage"})
+
+
+You can also enable the use of the HIPAA API URL::
+
+    >>> client = GeocodioClient(MY_KEY, hipaa_enabled=True)
+
 The result from the Geocod.io service is a dictionary including your query, its
 components, and a list of matching results::
 
@@ -75,6 +86,7 @@ accessed using the `coords` attribute::
     <http://postgis.net/docs/ST_Point.html>`_ formats easier the `coords`
     method returns a tuple in (longitude, latitude) format.
 
+
 Batch geocoding
 ===============
 
@@ -82,6 +94,14 @@ You can also geocode a list of addresses::
 
     >>> geocoded_addresses = geocodio.geocode(['1600 Pennsylvania Ave, Washington, DC',
             '3101 Patterson Ave, Richmond, VA, 23221'])
+
+
+And a list of address components::
+
+    >>> geocoded_addresses = geocodio.geocode([
+            {'street': '1600 Pennsylvania Ave', 'postal_code': '23221'},
+            {'street': '3101 Patterson Ave', 'postal_code': '23221'}
+        ])
 
 Return just the coordinates for the list of geocoded addresses::
 

--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -224,13 +224,14 @@ class GeocodioClient(object):
 
         Provides a single point of access for end users.
         """
-        if bool(address_data) != bool(components_data):
+        if (address_data is not None) != (components_data is not None):
             param_data = address_data if address_data is not None else components_data
             if isinstance(param_data, list):
                 return self.batch_geocode(param_data, **kwargs)
             else:
                 param_key = 'address' if address_data is not None else 'components'
-                return self.geocode_address(**{param_key: param_data}, **kwargs)
+                kwargs.update({param_key: param_data})
+                return self.geocode_address(**kwargs)
 
     @protect_fields
     def reverse_point(self, latitude, longitude, **kwargs):

--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -31,14 +31,6 @@ ALLOWED_FIELDS = [
     "timezone",
 ]
 
-GEOCODE_ALT_FIELDS = [
-    "street",
-    "city",
-    "state",
-    "postal_code",
-    "country"
-]
-
 
 def protect_fields(f):
     def wrapper(*args, **kwargs):

--- a/geocodio/data.py
+++ b/geocodio/data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import json
 
 
 class Address(dict):
@@ -100,13 +101,16 @@ class LocationCollection(list):
         results = []
         for index, result in enumerate(results_list):
             results.append(Location(result["response"], order=order))
-            self.lookups[result["query"]] = index
+            orig_query = result["query"]
+            lookup_key = json.dumps(orig_query) if isinstance(orig_query, dict) else orig_query
+            self.lookups[lookup_key] = index
+
         super(LocationCollection, self).__init__(results)
         self.order = order
 
     def get(self, key):
         """
-        Returns an individual Location by query lookup, e.g. address or point.
+        Returns an individual Location by query lookup, e.g. address, components dict, or point.
         """
 
         if isinstance(key, tuple):
@@ -120,6 +124,8 @@ class LocationCollection(list):
                 raise ValueError("Only float or float-coercable values can be passed")
 
             key = "{0},{1}".format(x, y)
+        elif isinstance(key, dict):
+            key = json.dumps(key)
 
         return self[self.lookups[key]]
 

--- a/tests/response/batch_components.json
+++ b/tests/response/batch_components.json
@@ -1,0 +1,104 @@
+{
+  "results": [
+    {
+      "query": {
+        "street": "1109 N Highland St",
+        "city": "Arlington",
+        "state": "VA"
+      },
+      "response": {
+        "input": {
+          "address_components": {
+            "number": "1109",
+            "predirectional": "N",
+            "street": "Highland",
+            "suffix": "St",
+            "formatted_street": "N Highland St",
+            "city": "A rlington",
+            "state": "VA",
+            "country": "US"
+          },
+          "formatted_address": "1109 N Highland St, Arlington, VA"
+        },
+        "results": [
+          {
+            "address_components": {
+              "number": "1109",
+              "predirectional": "N",
+              "street": "Highland",
+              "suffix": "St",
+              "formatted_street": "N Highland St",
+              "city": "A rlington",
+              "county": "Arlington County",
+              "state": "VA",
+              "zip": "22201",
+              "country": "US"
+            },
+            "formatted_address": "1109 N Highland St, Arlington, VA 22201",
+            "location": {
+              "lat": 38.886672,
+              "lng": -77.094735
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "source": "Arling ton"
+          },
+          {
+            "address_components": {
+              "number": "1109",
+              "predirectional": "N",
+              "street": "Highland",
+              "suffix": "St",
+              "formatted_street": "N Highland St",
+              "city": "Arlington",
+              "county": "Arlington County",
+              "state": "VA",
+              "zip": "22201",
+              "country": "US"
+            },
+            "formatted_address ": "1109 N Highland St, Arlington, VA 22201",
+            "location": {
+              "lat": 38.886665,
+              "lng": -77.094733
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "source": "Virginia Geographic Information Network (VGIN)"
+          }
+        ]
+      }
+    },
+    {
+      "query": {
+        "city": "Toronto",
+        "country": "CA"
+      },
+      "response": {
+        "input": {
+          "address_components": {
+            "city": "Toronto",
+            "country": "CA"
+          },
+          "formatted_address": "Toronto"
+        },
+        "results": [
+          {
+            "address_components": {
+              "city": "Toronto",
+              "state": "ON",
+              "country": "CA"
+            },
+            "formatted_address": "Toronto, ON",
+            "location": {
+              "lat": 43.70011,
+              "lng": -79.4163
+            },
+            "accuracy": 1,
+            "accuracy_type": "place",
+            "source": "CanVec+ by Natural Resources Canada"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/response/single_components.json
+++ b/tests/response/single_components.json
@@ -1,0 +1,28 @@
+{
+  "input": {
+    "address_components": {
+      "zip": "02210",
+      "country": "US"
+    },
+    "formatted_address": "02210"
+  },
+  "results": [
+    {
+      "address_components": {
+        "city": "Boston",
+        "county": "Suffolk County",
+        "state": "MA",
+        "zip": "02210",
+        "country": "US"
+      },
+      "formatted_address": "Boston, MA 02210",
+      "location": {
+        "lat": 42.347547,
+        "lng": -71.040645
+      },
+      "accuracy": 1,
+      "accuracy_type": "place",
+      "source": "TIGER/Line® dataset from the US Census Bureau"
+    }
+  ]
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,6 +30,8 @@ class TestDataTypes(unittest.TestCase):
             self.single_response = json.loads(single_json.read())
         with open(os.path.join(fixtures, "batch.json"), "r") as batch_json:
             self.batch_response = json.loads(batch_json.read())
+        with open(os.path.join(fixtures, "batch_components.json"), "r") as batch_components_json:
+            self.batch_components_response = json.loads(batch_components_json.read())
         with open(os.path.join(fixtures, "address.json"), "r") as address_json:
             self.address_response = json.loads(address_json.read())
         with open(os.path.join(fixtures, "missing_results.json"), "r") as missing_json:
@@ -118,6 +120,18 @@ class TestDataTypes(unittest.TestCase):
 
         # Case sensitive on the specific query
         self.assertRaises(KeyError, locations.get, "3101 Patterson Ave, richmond, va")
+
+        locations = LocationCollection(self.batch_components_response["results"])
+        self.assertEqual(locations.get({
+            "street": "1109 N Highland St",
+            "city": "Arlington",
+            "state": "VA"
+        }).coords, (38.886672, -77.094735))
+
+        # Requires all fields used for lookup
+        self.assertRaises(KeyError, locations.get,
+                          {"street": "1109 N Highland St",
+                           "city": "Arlington"})
 
         locations = LocationCollection(self.batch_reverse_response["results"])
 


### PR DESCRIPTION
Related to: #30

Changes:
* Give `geocode(...) ` 2 parameters: address_data + components_data
   * If both are populated or both are empty, nothing happens
   * If addres_data is provided (default first parameter), searching behaves like previusly
   * If comonents_data is a single dict or list of dicts populated with the supported fields [here](https://www.geocod.io/docs/#geocoding), geocoding occurs with components as the parameters instead of the freeform address string
* You can lookup a result based on the address components geocoded