### PR TITLE
Default to API version 1.4

### DIFF
--- a/geocodio/client.py
+++ b/geocodio/client.py
@@ -14,6 +14,8 @@ from geocodio import exceptions
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_API_VERSION = "1.4"
+
 ALLOWED_FIELDS = [
     "acs-demographics",
     "acs-economics",
@@ -79,7 +81,7 @@ class GeocodioClient(object):
     Client connection for Geocod.io API
     """
 
-    def __init__(self, key, order="lat", version="1.3", hipaa_enabled=False):
+    def __init__(self, key, order="lat", version=DEFAULT_API_VERSION, hipaa_enabled=False):
         """
         """
         self.hipaa_enabled = hipaa_enabled


### PR DESCRIPTION
__Addresses__ #32 

### Changes
* Added easy-access DEFAULT_API_VERSION constant for client
* Set default to most current version (1.4)
* Fixed tests that use api urls (all except client init tests) to use DEFAULT_API_VERSION for version

#### Testing
I ran this against flake8 tests and tox and it all passed.


#### Note
I missed the fact that the tests had v1.3 hard-coded when I approved the last PR for #32 (by @cyranix ) , unfortunately. I reverted that merge (sorry), and this should fix that issue and make it a little easier to bump the default API version going forward.

