### PR TITLE
Auto-load API version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-0.11.2 (2020-03-06)
+0.12.0 (2020-03-06)
 +++++++++++++++++++
 
 * Adds auto-loading of API version (thanks Unix-Code!)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+0.11.2 (2020-03-06)
++++++++++++++++++++
+
+* Adds auto-loading of API version (thanks Unix-Code!)
+
 0.11.1 (2019-11-07)
 +++++++++++++++++++
 

--- a/geocodio/__init__.py
+++ b/geocodio/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = "Ben Lopatin"
 __email__ = "ben@wellfire.co"
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 
 from geocodio.client import GeocodioClient  # noqa

--- a/geocodio/__init__.py
+++ b/geocodio/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = "Ben Lopatin"
 __email__ = "ben@wellfire.co"
-__version__ = "0.11.2"
+__version__ = "0.12.0"
 
 
 from geocodio.client import GeocodioClient  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=1.0.0
-httpretty==0.7.1
+httpretty>=0.9.7

--- a/tests/response/api_description.json
+++ b/tests/response/api_description.json
@@ -1,0 +1,4 @@
+{
+  "description": "Geocodio API v1.6",
+  "docs": "https://ww.geocod.io/docs/"
+}


### PR DESCRIPTION
#### Changes
* Client now has `version` field (for easy access)
* Client auto-loads api version and falls back to manual `DEFAULT_API_VERSION` or an override if present
  * This should ideally lead to the library (us) not maintaining the default API version anymore (though this would require an actual fallback of some kind or an error)
  * Auto-loading should be skippable if a version override is given or `auto_load_api_version` is set to False in the constructor
  * Auto-loading parses the api result [here](https://api.geocod.io/) for a version string

#### Notes
* The httpretty v0.7.2 doesn't seem to actually function in newer versions of python, so the latest version compatible with python 2 should be httpretty v0.9.7 - this fixes an SSL error