### PR TITLE
Add keyed-results for geocode + reverse geocode

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Contributors
 * `Shea Parkes <https://github.com/shea-parkes>`_
 * `David Malakh <https://github.com/Unix-Code>`_
 * `Andrew Harrision <https://github.com/cyranix>`_
+* `Franklin Liu <https://github.com/liufran1>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.0.0 (2020-06-18)
++++++++++++++++++++
+
+* Adds support for keying batch geocode results (thanks liufran1 and Unix-Code!)
+
 0.12.0 (2020-06-04)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 1.0.0 (2020-06-18)
 +++++++++++++++++++
 
-* Adds support for keying batch geocode results (thanks liufran1 and Unix-Code!)
+* Adds support for keying batch geocode and reverse geocode results (thanks liufran1 and Unix-Code!)
 
 0.12.0 (2020-06-04)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,8 @@ History
 1.0.0 (2020-06-18)
 +++++++++++++++++++
 
-* Adds support for keying batch geocode and reverse geocode results (thanks liufran1 and Unix-Code!)
+* Adds support for keying batch geocode results (thanks liufran1 and Unix-Code!)
+* Adds support for keying batch reverse geocode results (thanks liufran1 and Unix-Code!)
 
 0.12.0 (2020-06-04)
 +++++++++++++++++++

--- a/tests/response/batch_dict.json
+++ b/tests/response/batch_dict.json
@@ -1,0 +1,98 @@
+{
+    "results": 
+    {"1":
+        {
+            "query": "3101 patterson ave, richmond, va",
+            "response": {
+                "input": {
+                    "address_components": {
+                        "number": "3101",
+                        "street": "Patterson",
+                        "suffix": "Ave",
+                        "city": "Richmond",
+                        "state": "VA"
+                    },
+                    "formatted_address": "3101 Patterson Ave, Richmond VA"
+                },
+                "results": [
+                    {
+                        "address_components": {
+                            "number": "3101",
+                            "street": "Patterson",
+                            "suffix": "Ave",
+                            "city": "Richmond",
+                            "state": "VA",
+                            "zip": "23221"
+                        },
+                        "formatted_address": "3101 Patterson Ave, Richmond VA, 23221",
+                        "location": {
+                            "lat": 37.560890255102,
+                            "lng": -77.477400571429
+                        },
+                        "accuracy": 0.8
+                    }
+                ]
+            }
+        },
+    "2":
+        {
+            "query": "1657 W Broad St, Richmond, VA",
+            "response": {
+                "input": {
+                    "address_components": {
+                        "number": "1657",
+                        "predirectional": "W",
+                        "street": "Broad",
+                        "suffix": "St",
+                        "city": "Richmond",
+                        "state": "VA"
+                    },
+                    "formatted_address": "1657 W Broad St, Richmond VA"
+                },
+                "results": [
+                    {
+                        "address_components": {
+                            "number": "1657",
+                            "predirectional": "W",
+                            "street": "Broad",
+                            "suffix": "St",
+                            "city": "Richmond",
+                            "state": "VA",
+                            "zip": "23220"
+                        },
+                        "formatted_address": "1657 W Broad St, Richmond VA, 23220",
+                        "location": {
+                            "lat": 37.554895702703,
+                            "lng": -77.457561054054
+                        },
+                        "accuracy": 1
+                    },
+                    {
+                        "address_components": {
+                            "number": "1657",
+                            "predirectional": "W",
+                            "street": "Broad",
+                            "suffix": "St",
+                            "city": "Richmond",
+                            "state": "VA",
+                            "zip": "23220"
+                        },
+                        "formatted_address": "1657 W Broad St, Richmond VA, 23220",
+                        "location": {
+                            "lat": 37.554919546875,
+                            "lng": -77.45760096875
+                        },
+                        "accuracy": 0.8
+                    }
+                ]
+            }
+        },
+        "3":
+        {
+            "query": "",
+            "response": {
+                "error": "Could not parse address"
+            }
+        }
+    }
+}

--- a/tests/response/batch_dict_components.json
+++ b/tests/response/batch_dict_components.json
@@ -1,0 +1,105 @@
+{
+  "results": {"1":
+    {
+      "query": {
+        "street": "1109 N Highland St",
+        "city": "Arlington",
+        "state": "VA"
+      },
+      "response": {
+        "input": {
+          "address_components": {
+            "number": "1109",
+            "predirectional": "N",
+            "street": "Highland",
+            "suffix": "St",
+            "formatted_street": "N Highland St",
+            "city": "A rlington",
+            "state": "VA",
+            "country": "US"
+          },
+          "formatted_address": "1109 N Highland St, Arlington, VA"
+        },
+        "results": [
+          {
+            "address_components": {
+              "number": "1109",
+              "predirectional": "N",
+              "street": "Highland",
+              "suffix": "St",
+              "formatted_street": "N Highland St",
+              "city": "A rlington",
+              "county": "Arlington County",
+              "state": "VA",
+              "zip": "22201",
+              "country": "US"
+            },
+            "formatted_address": "1109 N Highland St, Arlington, VA 22201",
+            "location": {
+              "lat": 38.886672,
+              "lng": -77.094735
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "source": "Arling ton"
+          },
+          {
+            "address_components": {
+              "number": "1109",
+              "predirectional": "N",
+              "street": "Highland",
+              "suffix": "St",
+              "formatted_street": "N Highland St",
+              "city": "Arlington",
+              "county": "Arlington County",
+              "state": "VA",
+              "zip": "22201",
+              "country": "US"
+            },
+            "formatted_address ": "1109 N Highland St, Arlington, VA 22201",
+            "location": {
+              "lat": 38.886665,
+              "lng": -77.094733
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "source": "Virginia Geographic Information Network (VGIN)"
+          }
+        ]
+      }
+    },
+    "2":
+    {
+      "query": {
+        "city": "Toronto",
+        "country": "CA"
+      },
+      "response": {
+        "input": {
+          "address_components": {
+            "city": "Toronto",
+            "country": "CA"
+          },
+          "formatted_address": "Toronto"
+        },
+        "results": [
+          {
+            "address_components": {
+              "city": "Toronto",
+              "state": "ON",
+              "country": "CA"
+            },
+            "formatted_address": "Toronto, ON",
+            "location": {
+              "lat": 43.70011,
+              "lng": -79.4163
+            },
+            "accuracy": 1,
+            "accuracy_type": "place",
+            "source": "CanVec+ by Natural Resources Canada"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/response/batch_reverse_dict.json
+++ b/tests/response/batch_reverse_dict.json
@@ -1,0 +1,33 @@
+{
+    "results": {
+        "a": {
+            "query": "38.8977,-77.0365",
+            "response": {
+                "results": []
+            }
+        },
+        "b": {
+            "query": "37.538758,-77.433594",
+            "response": {
+                "results": [
+                    {
+                        "address_components": {
+                            "city": "Richmond",
+                            "suffix": "St",
+                            "zip": "23219",
+                            "number": "1025",
+                            "state": "VA",
+                            "street": "Capitol"
+                        },
+                        "formatted_address": "1025 Capitol St, Richmond, VA 23219",
+                        "location": {
+                            "lat": 37.538758,
+                            "lng": -77.433594
+                        },
+                        "accuracy": 1
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,9 +12,31 @@ import json
 import os
 import unittest
 
-from geocodio.data import Address
-from geocodio.data import Location
-from geocodio.data import LocationCollection
+from geocodio.data import Address, LocationCollectionUtils, Location, LocationCollection, LocationCollectionDict
+
+
+class TestLocationCollectionUtils(unittest.TestCase):
+    def test_extract_coords_key(self):
+        self.assertEqual(LocationCollectionUtils.extract_coords_key((-5.0, 5.0)), "-5.0,5.0")
+
+        self.assertEqual(LocationCollectionUtils.extract_coords_key(("-5.0", "5.0")), "-5.0,5.0")
+
+        self.assertRaises(ValueError, LocationCollectionUtils.extract_coords_key, (5.0,))
+
+        self.assertRaises(ValueError, LocationCollectionUtils.extract_coords_key, ("abc", "5.0"))
+
+    def test_get_lookup_key(self):
+        self.assertEqual(LocationCollectionUtils.get_lookup_key((-5.0, 5.0)), "-5.0,5.0")
+
+        self.assertEqual(LocationCollectionUtils.get_lookup_key(("-5.0", "5.0")), "-5.0,5.0")
+
+        self.assertEqual(LocationCollectionUtils.get_lookup_key({"1": "2"}), "{\"1\": \"2\"}")
+
+        self.assertEqual(LocationCollectionUtils.get_lookup_key(None), None)
+
+        self.assertEqual(LocationCollectionUtils.get_lookup_key("stuff"), "stuff")
+
+        self.assertEqual(LocationCollectionUtils.get_lookup_key(5), 5)
 
 
 class TestDataTypes(unittest.TestCase):
@@ -30,14 +52,18 @@ class TestDataTypes(unittest.TestCase):
             self.single_response = json.loads(single_json.read())
         with open(os.path.join(fixtures, "batch.json"), "r") as batch_json:
             self.batch_response = json.loads(batch_json.read())
+        with open(os.path.join(fixtures, "batch_dict.json"), "r") as batch_dict_json:
+            self.batch_dict_response = json.loads(batch_dict_json.read())
         with open(os.path.join(fixtures, "batch_components.json"), "r") as batch_components_json:
             self.batch_components_response = json.loads(batch_components_json.read())
+        with open(os.path.join(fixtures, "batch_dict_components.json"), "r") as batch_dict_components_json:
+            self.batch_dict_components_response = json.loads(batch_dict_components_json.read())
         with open(os.path.join(fixtures, "address.json"), "r") as address_json:
             self.address_response = json.loads(address_json.read())
         with open(os.path.join(fixtures, "missing_results.json"), "r") as missing_json:
             self.missing_results = json.loads(missing_json.read())
         with open(
-            os.path.join(fixtures, "batch_reverse.json"), "r"
+                os.path.join(fixtures, "batch_reverse.json"), "r"
         ) as batch_reverse_json:
             self.batch_reverse_response = json.loads(batch_reverse_json.read())
 
@@ -118,8 +144,8 @@ class TestDataTypes(unittest.TestCase):
             (37.560890255102, -77.477400571429),
         )
 
-        # Case sensitive on the specific query
-        self.assertRaises(KeyError, locations.get, "3101 Patterson Ave, richmond, va")
+        # # Case sensitive on the specific query
+        # self.assertRaises(KeyError, locations.get, "3101 Patterson Ave, richmond, va")
 
         locations = LocationCollection(self.batch_components_response["results"])
         self.assertEqual(locations.get({
@@ -128,14 +154,8 @@ class TestDataTypes(unittest.TestCase):
             "state": "VA"
         }).coords, (38.886672, -77.094735))
 
-        # Requires all fields used for lookup
-        self.assertRaises(KeyError, locations.get,
-                          {"street": "1109 N Highland St",
-                           "city": "Arlington"})
-
         locations = LocationCollection(self.batch_reverse_response["results"])
-
-        # The rendred query string value is acceptable
+        # The rendered query string value is acceptable
         self.assertEqual(
             locations.get("37.538758,-77.433594").coords, (37.538758, -77.433594)
         )
@@ -151,6 +171,195 @@ class TestDataTypes(unittest.TestCase):
         # This is unacceptable
         self.assertRaises(ValueError, locations.get, ("37.538758 N", "-77.433594 W"))
 
+    def test_collection_get_default(self):
+        """Ensure 'get' returns default if key-based lookup fails without an error"""
+        locations = LocationCollection(self.batch_response["results"])
+        self.assertEqual(locations.get("wrong original query lookup"), None)
 
-if __name__ == "__main__":
-    unittest.main()
+        locations = LocationCollection(self.batch_components_response["results"])
+        self.assertEqual(locations.get({
+            "street": "wrong street",
+            "city": "Arlington",
+            "state": "VA"
+        }, "test"), "test")
+
+        locations = LocationCollection(self.batch_reverse_response["results"])
+
+        self.assertEqual(locations.get((5, 5), None), None)
+        # If it can be coerced to a float it is acceptable
+        self.assertEqual(locations.get(("-4", "-5"), 5), 5)
+
+        # This is still unacceptable
+        self.assertRaises(ValueError, locations.get, ("37.538758 N", "-77.433594 W"))
+
+    def test_collection_magic_get_item(self):
+        """
+        Ensure LocationCollection[key] performs a key based lookup for an index corresponding with key
+        or performs an index lookup
+        """
+        locations = LocationCollection(self.batch_response["results"])
+        # Works with normal list indexing
+        self.assertEqual(locations[1].coords, (37.554895702703, -77.457561054054))
+        self.assertRaises(IndexError, locations.__getitem__, len(locations))
+
+        self.assertEqual(
+            locations["3101 patterson ave, richmond, va"].coords,
+            (37.560890255102, -77.477400571429),
+        )
+
+        # Case sensitive on the specific query
+        self.assertRaises(IndexError, locations.__getitem__, "3101 Patterson Ave, richmond, va")
+
+        locations = LocationCollection(self.batch_components_response["results"])
+        self.assertEqual(locations[{
+            "street": "1109 N Highland St",
+            "city": "Arlington",
+            "state": "VA"
+        }].coords, (38.886672, -77.094735))
+
+        # Requires all fields used for lookup
+        self.assertRaises(IndexError, locations.__getitem__,
+                          {"street": "1109 N Highland St",
+                           "city": "Arlington"})
+
+        locations = LocationCollection(self.batch_reverse_response["results"])
+        # The rendered query string value is acceptable
+        self.assertEqual(
+            locations["37.538758,-77.433594"].coords, (37.538758, -77.433594)
+        )
+        # A tuple of floats is acceptable
+        self.assertEqual(
+            locations[(37.538758, -77.433594)].coords, (37.538758, -77.433594)
+        )
+        # If it can be coerced to a float it is acceptable
+        self.assertEqual(
+            locations[("37.538758", "-77.433594")].coords, (37.538758, -77.433594)
+        )
+
+        # This is unacceptable
+        self.assertRaises(ValueError, locations.__getitem__, ("37.538758 N", "-77.433594 W"))
+
+    def test_dict_collection(self):
+        """Ensure that the LocationCollectionDict stores as a dict of Locations"""
+        self.assertTrue(isinstance(self.batch_dict_response, dict))
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+
+        self.assertTrue(isinstance(locations["1"], Location))
+
+    def test_dict_collection_coords(self):
+        """Ensure the coords property returns a list of suitable tuples"""
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+        self.assertEqual(
+            locations.coords,
+            {
+                "1": (37.560890255102, -77.477400571429),
+                "2": (37.554895702703, -77.457561054054),
+                "3": None
+            },
+        )
+
+        # Do the same with the order changed
+        locations = LocationCollectionDict(self.batch_dict_response["results"], order="lng")
+        self.assertEqual(
+            locations.coords,
+            {
+                "1": (-77.477400571429, 37.560890255102),
+                "2": (-77.457561054054, 37.554895702703),
+                "3": None
+            },
+        )
+
+    def test_dict_collection_addresses(self):
+        """Ensure that formatted addresses are returned"""
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+        self.assertEqual(
+            locations.formatted_addresses,
+            {
+                "1": "3101 Patterson Ave, Richmond VA, 23221",
+                "2": "1657 W Broad St, Richmond VA, 23220",
+                "3": "",
+            },
+        )
+
+    def test_dict_collection_get(self):
+        """Ensure 'get' performs a key based lookup"""
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+        self.assertEqual(
+            locations.get("3101 patterson ave, richmond, va").coords,
+            (37.560890255102, -77.477400571429),
+        )
+
+        # Ensure 'get' is able to look up by dictionary key
+        self.assertEqual(
+            locations.get("1").coords,
+            (37.560890255102, -77.477400571429),
+        )
+
+        locations = LocationCollectionDict(self.batch_dict_components_response["results"])
+        self.assertEqual(locations.get({
+            "street": "1109 N Highland St",
+            "city": "Arlington",
+            "state": "VA"
+        }).coords, (38.886672, -77.094735))
+
+    def test_dict_collection_get_default(self):
+        """Ensure 'get' returns default if key-based lookup fails without an error"""
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+        self.assertEqual(locations.get("wrong original query lookup"), None)
+
+        self.assertEqual(locations.get("25"), None)
+
+        locations = LocationCollectionDict(self.batch_dict_components_response["results"])
+        self.assertEqual(locations.get({
+            "street": "wrong street",
+            "city": "Arlington",
+            "state": "VA"
+        }, "test"), "test")
+
+    def test_dict_collection_magic_get_item(self):
+        """Ensure LocationCollectionDict[key] performs a key-based lookup, raising a KeyError on any missing key"""
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+        self.assertEqual(
+            locations["3101 patterson ave, richmond, va"].coords,
+            (37.560890255102, -77.477400571429),
+        )
+
+        # Ensure 'get' is able to look up by dictionary key
+        self.assertEqual(
+            locations["1"].coords,
+            (37.560890255102, -77.477400571429),
+        )
+
+        # Case sensitive on the specific query
+        self.assertRaises(KeyError, locations.__getitem__, "3101 Patterson Ave, richmond, va")
+
+        locations = LocationCollectionDict(self.batch_dict_components_response["results"])
+        self.assertEqual(locations[{
+            "street": "1109 N Highland St",
+            "city": "Arlington",
+            "state": "VA"
+        }].coords, (38.886672, -77.094735))
+
+        # Requires all fields used for lookup
+        self.assertRaises(KeyError, locations.__getitem__, {"street": "1109 N Highland St", "city": "Arlington"})
+
+    def test_dict_collection_magic_contains(self):
+        """Ensure "key in LocationDict(...)" checks if key would return a result with LocationDict(...)[key]"""
+        locations = LocationCollectionDict(self.batch_dict_response["results"])
+        self.assertTrue("3101 patterson ave, richmond, va" in locations)
+
+        # Ensure it also works with look up by dictionary key
+        self.assertTrue("1" in locations)
+
+        # Case sensitive on the specific query
+        self.assertFalse("3101 Patterson Ave, richmond, va" in locations)
+
+        locations = LocationCollectionDict(self.batch_dict_components_response["results"])
+        self.assertTrue({
+            "street": "1109 N Highland St",
+            "city": "Arlington",
+            "state": "VA"
+        } in locations)
+
+        # Requires all fields used for lookup
+        self.assertFalse({"street": "1109 N Highland St", "city": "Arlington"} in locations)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -144,9 +144,6 @@ class TestDataTypes(unittest.TestCase):
             (37.560890255102, -77.477400571429),
         )
 
-        # # Case sensitive on the specific query
-        # self.assertRaises(KeyError, locations.get, "3101 Patterson Ave, richmond, va")
-
         locations = LocationCollection(self.batch_components_response["results"])
         self.assertEqual(locations.get({
             "street": "1109 N Highland St",


### PR DESCRIPTION
__Related To:__ #27  

#### Changes
* `geocode(...)` now correctly handles a dict of arbitrary keys to addresses/address component dicts
* `reverse(...)` and `batch_reverse` now correctly handle a dict of arbitrary keys to points
  * This case actually isn't explicitly mentioned in the Geocod.io documentation, however it actually IS supported, so now that's reflected in the client
* `LocationCollectionDict`
  * Keyed-lookup of batch geocoding/reverse geocoding results
  * Has expected `x.get()`, `key in x`, and `x[key]` functionality for `dict` subclass
* `LocationCollection`
  * Has expected `x[key]` functionality for `list` subclass
* Lots more tests
* __Minor:__ `LocationCollectionUtils` houses a couple helper functions for dealing with collection data
* __Minor:__ The code now includes a lot more features from Python3, so this really is the point where Python2 support is officially dropped

#### Notes
I got a bit eager with trying to take a stab at this. Most of the credit goes to @liufran1 (#42) , even though the code is coming from my fork.