### PR TITLE
Add timeout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ Import the API client and ensure you have a valid API key::
     >>> from geocodio import GeocodioClient
     >>> client = GeocodioClient(YOUR_API_KEY)
 
+Note that you can pass in a timeout value in seconds (the default is no timeout)::
+
+    >>> client = GeocodioClient(YOUR_API_KEY, timeout=15)
+
 Geocoding
 ---------
 

--- a/src/geocodio/client.py
+++ b/src/geocodio/client.py
@@ -63,7 +63,7 @@ class GeocodioClient(object):
     Client connection for Geocod.io API
     """
 
-    def __init__(self, key, order="lat", version=None, hipaa_enabled=False, auto_load_api_version=True):
+    def __init__(self, key, order="lat", version=None, hipaa_enabled=False, auto_load_api_version=True, timeout=None):
         """
         """
         self.hipaa_enabled = hipaa_enabled
@@ -79,6 +79,7 @@ class GeocodioClient(object):
         if order not in ("lat", "lng"):
             raise ValueError("Order but be either `lat` or `lng`")
         self.order = order
+        self.timeout = timeout
 
     @staticmethod
     def _parse_curr_api_version(api_url):
@@ -103,7 +104,7 @@ class GeocodioClient(object):
         request_headers.update(headers)
         request_params.update(params)
         return getattr(requests, method)(
-            url, params=request_params, headers=request_headers, data=data
+            url, params=request_params, headers=request_headers, data=data, timeout=self.timeout
         )
 
     def parse(self, address):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,8 +29,7 @@ class ClientFixtures(object):
         self.reverse_url = "https://api.geocod.io/v{api_version}/reverse".format(api_version=DEFAULT_API_VERSION)
         # WARNING - Client will ignore auto-loading api version for all tests using the fixture
         self.client = GeocodioClient(self.TEST_API_KEY, auto_load_api_version=False)
-        self.timeout = 0.2
-        self.client_with_timeout = GeocodioClient(self.TEST_API_KEY, auto_load_api_version=False, timeout=self.timeout)
+        self.client_with_timeout = GeocodioClient(self.TEST_API_KEY, auto_load_api_version=False, timeout=0.2)
         self.err = '{"error": "We are testing"}'
 
 


### PR DESCRIPTION
Implements the ability to pass a timeout when creating the client object. See https://github.com/bennylope/pygeocodio/issues/33