### PR TITLE
feat: Add custom_base_domain flag to init method

### DIFF
--- a/src/geocodio/client.py
+++ b/src/geocodio/client.py
@@ -63,12 +63,17 @@ class GeocodioClient(object):
     Client connection for Geocod.io API
     """
 
-    def __init__(self, key, order="lat", version=None, hipaa_enabled=False, auto_load_api_version=True, timeout=None):
+    def __init__(self, key, order="lat", version=None, hipaa_enabled=False, auto_load_api_version=True, timeout=None, custom_base_domain=None):
         """
         """
-        self.hipaa_enabled = hipaa_enabled
-        self.BASE_DOMAIN = "https://api{hipaa_append}.geocod.io".format(
-            hipaa_append=('-hipaa' if self.hipaa_enabled else ''))
+        if custom_base_domain is None:
+            self.hipaa_enabled = hipaa_enabled
+            self.BASE_DOMAIN = "https://api{hipaa_append}.geocod.io".format(
+                hipaa_append=('-hipaa' if self.hipaa_enabled else ''))
+        else:
+            self.BASE_DOMAIN = custom_base_domain
+        
+
         if version is None and auto_load_api_version:
             version = self._parse_curr_api_version(self.BASE_DOMAIN)
         # Fall back to manual default API version if couldn't be found or isn't overridden

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,6 +47,10 @@ class TestClientInit(unittest.TestCase):
         self.assertFalse(client.hipaa_enabled)
         self.assertTrue(client.BASE_URL.startswith("https://api.geocod.io"))
 
+    def test_custom_base_domain(self):
+        client = GeocodioClient(self.TEST_API_KEY, custom_base_domain="http://127.0.0.1")
+        self.assertTrue(client.BASE_URL.startswith("http://127.0.0.1"))
+
     def test_diff_version(self):
         client = GeocodioClient(self.TEST_API_KEY, version="1.0")
         self.assertTrue(client.BASE_URL.startswith("https://api.geocod.io/v1.0"))


### PR DESCRIPTION
This makes it possible to use the `pygeocodio` library with a custom geocodio installation