### PR TITLE
Add limit parameter to single address and batch geocoding

### DIFF
--- a/src/geocodio/client.py
+++ b/src/geocodio/client.py
@@ -138,10 +138,11 @@ class GeocodioClient(object):
         address. Accepts either a list or dictionary of addresses
         """
         fields = ",".join(kwargs.pop("fields", []))
+        limit = kwargs.pop("limit", 0)
         response = self._req(
             "post",
             verb="geocode",
-            params={"fields": fields},
+            params={"fields": fields, "limit": limit},
             data=json.dumps(addresses),
         )
         if response.status_code != 200:
@@ -210,7 +211,8 @@ class GeocodioClient(object):
         }
         """
         fields = ",".join(kwargs.pop("fields", []))
-        params = {"fields": fields}
+        limit = kwargs.pop("limit", 0)
+        params = {"fields": fields, "limit": limit}
         if address is not None:
             params["q"] = address
         else:


### PR DESCRIPTION
# Summary
Implements the possibility to add `limit` optional parameter in the `geocode` function, used in both `geocode_address` and `batch_geocode`.

## Issue
Solves #57.

# Testing
## curl
In the terminal:
```
curl -X POST \
  -H "Content-Type: application/json" \
  -d '["4410 S Highway 17 92, Casselberry FL", "17015 Walnut Grove Drive, Morgan Hill CA"]' \
  https://api.geocod.io/v1.7/geocode\?api_key\=03335b96223739b5bb780288b5735b9b43b6b60\&limit\=0
```

That's to ensure `limit=0` is the correct default value ✅ 

And then:
```
curl -X POST \
  -H "Content-Type: application/json" \
  -d '["4410 S Highway 17 92, Casselberry FL", "17015 Walnut Grove Drive, Morgan Hill CA"]' \
  https://api.geocod.io/v1.7/geocode\?api_key\=03335b96223739b5bb780288b5735b9b43b6b60\&limit\=1
```
## Python tests
To ensure we're only getting the amount of results we requested ✅ 

I used my own API key and ran:
```
python setup.py test
```

Result:
```
----------------------------------------------------------------------
Ran 46 tests in 0.338s

OK
```
## tox
On the other hand, I ran `tox` as well, getting the following result:
```
  py37: OK (6.64=setup[5.16]+cmd[1.48] seconds)
  py38: FAIL code 1 (2.22=setup[1.85]+cmd[0.37] seconds)
  py39: SKIP (0.03 seconds)
  py310: SKIP (0.00 seconds)
  py311: SKIP (0.00 seconds)
  flake8: FAIL code 1 (2.94=setup[2.64]+cmd[0.30] seconds)
  evaluation failed :( (12.08 seconds)
```

I think it wasn't working correctly, at least if you follow the `CONTRIBUTION` readme. I don't think the changes I introduced break anything.